### PR TITLE
Add transparent menu overlay and countdown start

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,10 +11,12 @@
     .bar { flex: 1; height: 8px; background: rgba(255,255,255,0.15); border-radius: 999px; overflow: hidden; }
     .fill { height: 100%; background: linear-gradient(90deg, #7bdcff, #91ffb1); width: 0%; }
     .chip { background: rgba(255,255,255,0.08); padding: 4px 10px; border-radius: 999px; font-size: 12px; }
-    #overlay { position: fixed; inset: 0; display: flex; align-items: center; justify-content: center; background: rgba(0,0,0,0.7); color: white; text-align: center; }
-    #panel { background: rgba(0,0,0,0.85); padding: 20px; border-radius: 12px; max-width: 600px; }
-    button { margin-top: 12px; padding: 10px 16px; background: #222; color: #eee; border: 1px solid #555; border-radius: 8px; cursor: pointer; font-weight: bold; }
-    button:hover { background: #333; }
+    #overlay { position: fixed; inset: 0; display: flex; align-items: center; justify-content: center; background: rgba(10,12,24,0.55); color: white; text-align: center; opacity: 1; transition: opacity 0.6s ease; backdrop-filter: blur(8px); }
+    #overlay.fade-out { opacity: 0; pointer-events: none; }
+    #panel { background: rgba(6,10,18,0.75); padding: 24px; border-radius: 16px; max-width: 600px; border: 1px solid rgba(255,255,255,0.08); box-shadow: 0 18px 40px rgba(0,0,0,0.35); }
+    button { margin-top: 12px; padding: 12px 18px; background: linear-gradient(135deg, #2a4dff, #23b5ff); color: #f4f9ff; border: none; border-radius: 999px; cursor: pointer; font-weight: 600; letter-spacing: 0.5px; box-shadow: 0 10px 25px rgba(0,0,0,0.25); transition: transform 0.2s ease, box-shadow 0.2s ease; }
+    button:hover { transform: translateY(-1px); box-shadow: 0 14px 32px rgba(0,0,0,0.3); }
+    button:disabled { opacity: 0.6; cursor: default; }
     [hidden] { display: none !important; }
   </style>
 </head>
@@ -53,35 +55,154 @@
     const statusEl = document.getElementById('status');
 
     let progress = 0;
-    let baseSpeed = 0.05;
+    const baseSpeed = 0.05;
     let gameOverFlag = false;
+    const fadeDuration = 600;
+    let startRequested = false;
+    let gameActive = false;
+    let gameStarted = false;
+
+    const countdownSeconds = 3;
+    let countdownTimerId = null;
+    let countdownSprite;
+    let countdownTexture;
+    let countdownCanvas;
+    let countdownCtx;
+    let countdownHideTimeoutId = null;
+    let fadeTimeoutId = null;
 
     // controle de câmera
     let yaw = 0;
     let pitch = 0;
-    let sensitivity = 0.002;
+    const sensitivity = 0.002;
     let pointerLocked = false;
 
     // calibração automática (média inicial)
-    let calibrationSamples = [];
+    const calibrationSamples = [];
     let calibrationDone = false;
-    let yawOffset = 0;
     let pitchOffset = 0;
 
-    playBtn.onclick = start;
+    playBtn.onclick = () => {
+      if (startRequested) return;
+      startRequested = true;
+      playBtn.disabled = true;
+      gameActive = false;
+      gameStarted = false;
+      statusEl.textContent = 'Prepare-se';
+      let fadeHandled = false;
 
-    function start() {
-      overlay.hidden = true;
+      const finalizeFade = () => {
+        if (fadeHandled) return;
+        fadeHandled = true;
+        overlay.hidden = true;
+        overlay.classList.remove('fade-out');
+        overlay.removeEventListener('transitionend', handleFadeEnd);
+        if (fadeTimeoutId) {
+          clearTimeout(fadeTimeoutId);
+          fadeTimeoutId = null;
+        }
+        startCountdown();
+      };
 
-      // tenta entrar em fullscreen (mobile)
-      if (document.documentElement.requestFullscreen) {
-        document.documentElement.requestFullscreen();
-      } else if (document.documentElement.webkitRequestFullscreen) {
-        document.documentElement.webkitRequestFullscreen();
+      const handleFadeEnd = (event) => {
+        if (event.target === overlay && event.propertyName === 'opacity') {
+          finalizeFade();
+        }
+      };
+
+      fadeTimeoutId = setTimeout(finalizeFade, fadeDuration + 80);
+      overlay.addEventListener('transitionend', handleFadeEnd);
+      overlay.classList.add('fade-out');
+      attemptFullscreen();
+    };
+
+    function attemptFullscreen() {
+      const element = document.documentElement;
+      const request = element.requestFullscreen || element.webkitRequestFullscreen || element.msRequestFullscreen;
+      if (request) {
+        request.call(element);
       }
+    }
 
-      init();
-      animate();
+    function ensureCountdownSprite() {
+      if (countdownSprite) return;
+      countdownCanvas = document.createElement('canvas');
+      countdownCanvas.width = countdownCanvas.height = 512;
+      countdownCtx = countdownCanvas.getContext('2d');
+      countdownTexture = new THREE.CanvasTexture(countdownCanvas);
+      const material = new THREE.SpriteMaterial({ map: countdownTexture, transparent: true });
+      material.depthWrite = false;
+      countdownSprite = new THREE.Sprite(material);
+      countdownSprite.scale.set(3, 3, 1);
+      countdownSprite.position.set(0, 2.4, -10);
+      countdownSprite.visible = false;
+      countdownSprite.renderOrder = 2;
+      scene.add(countdownSprite);
+    }
+
+    function updateCountdownTexture(value) {
+      ensureCountdownSprite();
+      const isNumber = typeof value === 'number';
+      const text = value.toString();
+      const size = countdownCanvas.width;
+      const center = size / 2;
+      countdownCtx.clearRect(0, 0, size, size);
+      countdownCtx.save();
+      countdownCtx.fillStyle = 'rgba(14,20,35,0.68)';
+      countdownCtx.beginPath();
+      countdownCtx.arc(center, center, size * 0.42, 0, Math.PI * 2);
+      countdownCtx.fill();
+      countdownCtx.lineWidth = size * 0.04;
+      countdownCtx.strokeStyle = 'rgba(90, 170, 255, 0.5)';
+      countdownCtx.stroke();
+      countdownCtx.fillStyle = '#f4f9ff';
+      countdownCtx.textAlign = 'center';
+      countdownCtx.textBaseline = 'middle';
+      countdownCtx.shadowColor = 'rgba(0,0,0,0.35)';
+      countdownCtx.shadowBlur = 28;
+      const fontSize = isNumber ? Math.round(size * 0.42) : Math.round(size * 0.28);
+      countdownCtx.font = `700 ${fontSize}px system-ui, sans-serif`;
+      countdownCtx.fillText(text, center, center + (isNumber ? size * 0.02 : 0));
+      countdownCtx.restore();
+      countdownTexture.needsUpdate = true;
+    }
+
+    function startCountdown() {
+      if (countdownTimerId) {
+        clearInterval(countdownTimerId);
+      }
+      if (countdownHideTimeoutId) {
+        clearTimeout(countdownHideTimeoutId);
+        countdownHideTimeoutId = null;
+      }
+      ensureCountdownSprite();
+      countdownSprite.visible = true;
+      gameStarted = false;
+      gameActive = false;
+      let current = countdownSeconds;
+      updateCountdownTexture(current);
+      countdownTimerId = setInterval(() => {
+        current -= 1;
+        if (current > 0) {
+          updateCountdownTexture(current);
+          return;
+        }
+        clearInterval(countdownTimerId);
+        countdownTimerId = null;
+        updateCountdownTexture('Vai!');
+        countdownHideTimeoutId = setTimeout(() => {
+          if (countdownSprite) countdownSprite.visible = false;
+        }, 500);
+        activateGame();
+      }, 1000);
+    }
+
+    function activateGame() {
+      if (gameStarted) return;
+      gameStarted = true;
+      gameActive = true;
+      last = performance.now();
+      statusEl.textContent = 'Equilibre-se';
     }
 
     function init() {
@@ -114,8 +235,14 @@
         renderer.setSize(window.innerWidth, window.innerHeight);
       });
 
-      addEventListener('keydown', (e) => { if(e.key==='a') keys.a = true; if(e.key==='d') keys.d = true; });
-      addEventListener('keyup', (e) => { if(e.key==='a') keys.a = false; if(e.key==='d') keys.d = false; });
+      const handleKey = (isPressed) => (event) => {
+        const key = event.key.toLowerCase();
+        if (key in keys) {
+          keys[key] = isPressed;
+        }
+      };
+      addEventListener('keydown', handleKey(true));
+      addEventListener('keyup', handleKey(false));
 
       document.body.addEventListener('click', () => {
         if (!pointerLocked) {
@@ -140,7 +267,6 @@
         let beta = e.beta || 0;
         let alpha = e.alpha || 0;
 
-        let currentYaw = THREE.MathUtils.degToRad(alpha);
         let currentPitch = Math.abs(orientation) === 90 ? THREE.MathUtils.degToRad(gamma) * 0.5 : THREE.MathUtils.degToRad(beta) * 0.5;
 
         if (!calibrationDone) {
@@ -164,6 +290,10 @@
           }
         }
       });
+
+      ensureCountdownSprite();
+      countdownSprite.visible = false;
+      fillEl.style.width = '0%';
     }
 
     function update(dt) {
@@ -181,8 +311,6 @@
       angVel += (drift * 0.5 + control * baseControlPower) * dt;
       angVel *= Math.pow(damping, dt * 60);
       angle += angVel * dt;
-
-      camera.rotation.set(pitch, yaw, angle);
       camera.position.z -= 2 * dt;
 
       progress = Math.min(1, progress + baseSpeed * dt);
@@ -201,13 +329,33 @@
       const dt = Math.min(0.05, (now - last) / 1000);
       last = now;
 
-      update(dt);
+      if (gameActive) {
+        update(dt);
+      }
+
+      camera.rotation.set(pitch, yaw, angle);
       renderer.render(scene, camera);
     }
 
+    init();
+    animate();
+
     function gameOver(win) {
       gameOverFlag = true;
+      gameActive = false;
+      if (countdownTimerId) {
+        clearInterval(countdownTimerId);
+        countdownTimerId = null;
+      }
+      if (countdownHideTimeoutId) {
+        clearTimeout(countdownHideTimeoutId);
+        countdownHideTimeoutId = null;
+      }
+      if (countdownSprite) {
+        countdownSprite.visible = false;
+      }
       overlay.hidden = false;
+      overlay.classList.remove('fade-out');
       document.getElementById('panel').innerHTML = win
         ? '<h1>Você conseguiu!</h1><p>Chegou ao fim da corda.</p><button onclick="location.reload()">Recomeçar</button>'
         : '<h1>Você caiu!</h1><p>Perdeu o equilíbrio e caiu na lava.</p><button onclick="location.reload()">Recomeçar</button>';


### PR DESCRIPTION
## Summary
- add a fade-out transition to the start overlay with a translucent, styled panel so the scene is visible behind it
- initialize the scene immediately, show a world-anchored 3D countdown after the fade, and only start gameplay when it finishes
- streamline input handling and timer cleanup to keep the HUD responsive

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cafeef7c4c8323bfa9059e5c77c856